### PR TITLE
ci: Add a Github workflow for building and releasing *.so files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,62 @@
+name: Relase programs
+
+on:
+  push:
+    tags:
+      - "*"
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Install Rust stable
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Install nightly Rust nightly
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+
+      - uses: Swatinem/rust-cache@v1
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: Install Light Protocol toolchain
+        run: |
+          curl -s https://raw.githubusercontent.com/Lightprotocol/install/main/light-protocol-install.sh | bash -s -- --no-prompt
+          echo "$HOME/.local/light-protocol/bin" >> $GITHUB_PATH
+
+      - name: Build
+        working-directory: ./light-system-programs
+        run: |
+          light-anchor build
+          cp target/deploy/merkle_tree_program.so ../merkle_tree_program.so
+          cp target/deploy/verifier_program_zero.so ../verifier_program_zero.so
+          cp target/deploy/verifier_program_storage.so ../verifier_program_storage.so
+          cp target/deploy/verifier_program_one.so ../verifier_program_one.so
+          cp target/deploy/verifier_program_two.so ../verifier_program_two.so
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          token: ${{ secrets.PAT_TOKEN }}
+          files: |
+            merkle_tree_program.so
+            verifier_program_zero.so
+            verifier_program_storage.so
+            verifier_program_one.so
+            verifier_program_two.so

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "market-place-verifier"]
-path = market-place-verifier
-	url = git@github.com:Lightprotocol/market-place-verifier.git
 [submodule "light-macros"]
 	path = light-macros
 	url = git@github.com:Lightprotocol/light-macros.git


### PR DESCRIPTION
These BPF objects are going to be used in development environments for PSPs (Private Solana Programs).